### PR TITLE
Added the ability to delete a single record from fusion tables

### DIFF
--- a/fusionsync.sh
+++ b/fusionsync.sh
@@ -153,6 +153,19 @@ IFS=$'\t'; get_db_data | while read -r country affiliation operators signed_mou 
       "https://www.googleapis.com/fusiontables/v2/query?sql=${SQL_QUERY}&alt=csv" > /dev/null
   fi
 done
+
+if [ "$DELETE_SET" == "true" ]; then
+  # delete from fusion table
+  SQL_QUERY=$(encode_space "SELECT ROWID FROM ${resourceID} WHERE Location='$(encode_space ${COUNTRY_DROP})'")
+  status_code=$(curl -s -H "Content-Length:0" -X POST \
+    "https://www.googleapis.com/fusiontables/v2/query?sql=${SQL_QUERY}&key=${key}&alt=csv" \
+    | sed -n '2p')
+  SQL_QUERY=$(encode_space "DELETE FROM ${resourceID} WHERE ROWID='${status_code}'")
+  printf "Deleting record for ${COUNTRY_DROP}\n"
+  curl -s -H "Content-Length:0" -H "Authorization: Bearer $access_token" \
+    -X POST "https://www.googleapis.com/fusiontables/v2/query?sql=${SQL_QUERY}&alt=csv" > /dev/null
+fi
+
 unset IFS
 printf "Database sync complete\n"
 exit

--- a/fusionsync.sh
+++ b/fusionsync.sh
@@ -160,10 +160,14 @@ if [ "$DELETE_SET" == "true" ]; then
   status_code=$(curl -s -H "Content-Length:0" -X POST \
     "https://www.googleapis.com/fusiontables/v2/query?sql=${SQL_QUERY}&key=${key}&alt=csv" \
     | sed -n '2p')
-  SQL_QUERY=$(encode_space "DELETE FROM ${resourceID} WHERE ROWID='${status_code}'")
-  printf "Deleting record for ${COUNTRY_DROP}\n"
-  curl -s -H "Content-Length:0" -H "Authorization: Bearer $access_token" \
-    -X POST "https://www.googleapis.com/fusiontables/v2/query?sql=${SQL_QUERY}&alt=csv" > /dev/null
+  if [ ! "$status_code" == "" ] || [ ! -z "$status_code" ]; then
+    SQL_QUERY=$(encode_space "DELETE FROM ${resourceID} WHERE ROWID='${status_code}'")
+    printf "Deleting record for ${COUNTRY_DROP}\n"
+    curl -s -H "Content-Length:0" -H "Authorization: Bearer $access_token" \
+      -X POST "https://www.googleapis.com/fusiontables/v2/query?sql=${SQL_QUERY}&alt=csv" > /dev/null
+  else
+    printf "Record for ${COUNTRY_DROP} does not exist on the fusion table\n"
+  fi
 fi
 
 unset IFS

--- a/fusionsync.sh
+++ b/fusionsync.sh
@@ -6,7 +6,7 @@ DB_USER_SET="false"
 DB_PASSWD_SET="false"
 
 UPDATE="false"
-ENTITY_ID_DROP=""
+COUNTRY_DROP=""
 DB_USER=""
 DB_PASSWD=""
 DB_NAME="drupaldb"
@@ -16,7 +16,7 @@ source common.sh
 ensure_fresh_access_token
 
 usage() {
-  printf "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD\n"
+  printf "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD\n"
 }
 
 # attempt connection to db with supplied credentials
@@ -80,7 +80,7 @@ while [ "$1" != "" ]; do
     -d | --delete )
       shift
       if [ "$UPDATE_SET" == "false" ]; then
-        ENTITY_ID_DROP="$1"
+        COUNTRY_DROP="$1"
         DELETE_SET="true"
       else
         usage
@@ -118,6 +118,7 @@ fi
 
 key="AIzaSyBPmZQT3CpatiuKpr-dXUEhAjeDTha1Syo"
 resourceID="10wEN3u3XsSdjmyZjlSvTqe8mNlpQWOjhzLlVp0rV"
+
 IFS=$'\t'; get_db_data | while read -r country affiliation operators signed_mou saml saml_complete \
   edugain edugain_complete eduroam eduroam_complete progress flag_url; do
   if [ "$UPDATE" == "true" ]; then

--- a/tests/args.bats
+++ b/tests/args.bats
@@ -1,25 +1,25 @@
 @test "no arguments provided" {
   run ../fusionsync.sh
   [ "$status" -eq 1 ]
-  [ "$output" = "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD" ]
+  [ "$output" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }
 
 @test "contradictory arguments provided" {
-  run ../fusionsync.sh --update --delete 14 --user drupaluser
+  run ./fusionsync.sh --update --delete 14 --user drupaluser
   [ "$status" -eq 1 ]
-  [ "$output" = "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD" ]
+  [ "$output" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }
 
 @test "invalid arguments provided" {
-  run ../fusionsync.sh --unknown
+  run ./fusionsync.sh --unknown
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Unknown argument '--unknown'" ]
-  [ "${lines[1]}" = "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD" ]
+  [ "${lines[1]}" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }
 
 @test "missing/invalid user provided" {
-  run ../fusionsync.sh --user
+  run ./fusionsync.sh --user
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Invalid user ''" ]
-  [ "${lines[1]}" = "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD" ]
+  [ "${lines[1]}" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }

--- a/tests/args.bats
+++ b/tests/args.bats
@@ -1,5 +1,5 @@
 @test "no arguments provided" {
-  run ../fusionsync.sh
+  run ./fusionsync.sh
   [ "$status" -eq 1 ]
   [ "$output" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }

--- a/tests/db_opts.bats
+++ b/tests/db_opts.bats
@@ -1,13 +1,13 @@
 @test "attempted connection to db with incorrect credentials" {
-  run ../fusionsync.sh --user fakeuser --password fakepassword
+  run ./fusionsync.sh --user fakeuser --password fakepassword
   [ "$status" -eq 1 ]
   [ "${lines[1]}" = "Failed to connect to database" ]
-  [ "${lines[2]}" = "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD" ]
+  [ "${lines[2]}" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }
 
 @test "attempted connection to db with incorrect password" {
-  run ../fusionsync.sh --user drupaluser --password fakepassword
+  run ./fusionsync.sh --user drupaluser --password fakepassword
   [ "$status" -eq 1 ]
   [ "${lines[1]}" = "Failed to connect to database" ]
-  [ "${lines[2]}" = "Usage: fusionsync.sh [--update | --delete ENTITYID] --user DBUSER --password PASSWORD" ]
+  [ "${lines[2]}" = "Usage: fusionsync.sh [--update | --delete COUNTRY] --user DBUSER --password PASSWORD" ]
 }


### PR DESCRIPTION
Functionality has been added to delete individual records from fusion tables. This is potentially useful for getting rid of botched updates before a re-sync